### PR TITLE
Modernize CMake and make minimal cpp version c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,7 @@ project(bezier
   LANGUAGES CXX
   VERSION 0.3.2)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-add_compile_options(-fPIC -O2)
-
 find_package(Eigen3 REQUIRED)
-include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR} include)
 
 set(Bezier_SRC
   ${PROJECT_SOURCE_DIR}/src/bezier.cpp
@@ -35,15 +28,24 @@ else()
 endif()
 
 target_include_directories(bezier PUBLIC
-  $<BUILD_INTERFACE:${Bezier_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+target_link_libraries(bezier PUBLIC Eigen3::Eigen)
 
-set_target_properties(bezier PROPERTIES VERSION ${PROJECT_VERSION})
-set_target_properties(bezier PROPERTIES PUBLIC_HEADER "${Bezier_INC}")
+set_target_properties(bezier PROPERTIES
+  VERSION ${PROJECT_VERSION}
+  CXX_EXTENSIONS OFF
+  POSITION_INDEPENDENT_CODE ON
+  PUBLIC_HEADER "${Bezier_INC}"
+)
+target_compile_features(bezier PUBLIC cxx_std_17)
+target_compile_options(bezier PRIVATE -O3 -DNDEBUG)
 
 # install rules
 install(TARGETS bezier
   EXPORT bezier-export DESTINATION "lib"
   PUBLIC_HEADER DESTINATION "include/Bezier")
 install(EXPORT bezier-export DESTINATION "lib/cmake/Bezier" FILE BezierConfig.cmake)
+
+add_library(bezier::bezier ALIAS bezier)

--- a/include/Bezier/declarations.h
+++ b/include/Bezier/declarations.h
@@ -18,7 +18,6 @@
 #define DECLARATIONS_H
 
 #include <Eigen/Dense>
-#include <vector>
 
 /*!
  * Nominal namespace containing class pre-definitions and typedefs
@@ -34,15 +33,6 @@ namespace Bezier
  * static caching is used for common data (coefficient matrices)
  */
 class Curve;
-
-/*!
- * \brief A polyline class
- *
- * A class for operations on polyline, mainly used for
- * polyline representation of curves. Underlying structure
- * is a vector of points.
- */
-class PolyLine;
 
 /*!
  * \brief A Bezier polycurve class

--- a/src/bezier.cpp
+++ b/src/bezier.cpp
@@ -10,16 +10,6 @@ using namespace Bezier;
 
 ///// Additional declarations
 
-#ifndef __cpp_lib_make_unique
-namespace std
-{
-template <typename T, typename... Args> inline std::unique_ptr<T> make_unique(Args&&... args)
-{
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-} // namespace std
-#endif
-
 struct _PolynomialRoots : public std::vector<double>
 {
   explicit _PolynomialRoots(unsigned reserve) { std::vector<double>::reserve(reserve); }
@@ -485,11 +475,7 @@ PointVector Curve::intersections(const Curve& curve) const
       subcurves.emplace_back(splittingCoeffsLeft(N_, t[k] - _epsilon / 2) * new_cp);
       subcurves.emplace_back(splittingCoeffsRight(N_, t[k] + _epsilon / 2) * new_cp);
 
-#if __cpp_init_captures
       std::for_each(t.begin() + k + 1, t.end(), [t = t[k]](double& x) { x = (x - t) / (1 - t); });
-#else
-      std::for_each(t.begin() + k + 1, t.end(), [&t, k](double& x) { x = (x - t[k]) / (1 - t[k]); });
-#endif
     }
 
     // create all pairs of subcurves
@@ -500,12 +486,7 @@ PointVector Curve::intersections(const Curve& curve) const
 
   while (!subcurve_pairs.empty())
   {
-#if __cpp_structured_bindings
     auto [cp_a, cp_b] = std::move(subcurve_pairs.back());
-#else
-    Eigen::MatrixX2d cp_a, cp_b;
-    std::tie(cp_a, cp_b) = std::move(subcurve_pairs.back());
-#endif
     subcurve_pairs.pop_back();
 
     BoundingBox bbox1(Point(cp_a.col(0).minCoeff(), cp_a.col(1).minCoeff()),


### PR DESCRIPTION
- Use target_compile_features(cxx_std_17) instead of CMAKE_CXX_STANDARD
- Add target_link_libraries with Eigen3::Eigen
- Modernize target properties with multi-line format
- Add bezier::bezier alias for better CMake integration
- Set POSITION_INDEPENDENT_CODE ON
- Add -O3 -DNDEBUG optimization flags
- Fix include path to use CMAKE_CURRENT_SOURCE_DIR
- Remove __cpp_lib_make_unique polyfill (std::make_unique native in C++17)
- Remove __cpp_init_captures macro (lambda init captures native in C++17)
- Remove __cpp_structured_bindings macro (structured bindings native in C++17)
- Remove unused PolyLine class declaration
- Remove unnecessary #include <vector> from declarations.h"

Close #39